### PR TITLE
Pass coord batches as Float64Array through dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Coordinate batches cross dispatch and the worker boundary as `Float64Array`
+  instead of boxed plain arrays; `set-coord-array` fills the buffer in place
+
 ## [0.1.0-alpha9] - 2026-08-24
 
 ### Added

--- a/src/cljc/net/willcohen/proj/proj-handler-overrides.mjs
+++ b/src/cljc/net/willcohen/proj/proj-handler-overrides.mjs
@@ -334,7 +334,7 @@ function readCoordDataAndFree(mod, coordAllocations) {
   const coordData = [];
   for (const alloc of coordAllocations) {
     coordData.push(
-      Array.from(mod.HEAPF64.subarray(alloc.heapOffset, alloc.heapOffset + alloc.numFloats)),
+      mod.HEAPF64.slice(alloc.heapOffset, alloc.heapOffset + alloc.numFloats),
     );
     mod._free(alloc.mallocPtr);
   }

--- a/src/cljc/net/willcohen/proj/proj.cljc
+++ b/src/cljc/net/willcohen/proj/proj.cljc
@@ -94,23 +94,27 @@
    (defn set-coord-array
      "Set coordinate values in the Float64Array buffer of a JS-side coord array."
      [coord-array allocated]
-     (let [flattened (cond
-                       (and (array? coord-array)
-                            (every? number? coord-array))
-                       coord-array
+     (let [^js buf (.-buffer allocated)]
+       (cond
+         (and (array? coord-array)
+              (every? number? coord-array))
+         (.set buf coord-array 0)
 
-                       (and (array? coord-array)
-                            (array? (aget coord-array 0)))
-                       (let [result #js []]
-                         (dotimes [i (.-length coord-array)]
-                           (let [inner (aget coord-array i)]
-                             (dotimes [j (.-length inner)]
-                               (.push result (aget inner j)))))
-                         result)
+         (and (array? coord-array)
+              (array? (aget coord-array 0)))
+         (loop [i 0
+                off 0]
+           (when (< i (.-length coord-array))
+             (let [inner (aget coord-array i)
+                   len (.-length inner)]
+               (when (> (+ off len) (.-length buf))
+                 (throw (js/RangeError. "coords exceed coord-array capacity")))
+               (dotimes [j len]
+                 (aset buf (+ off j) (aget inner j)))
+               (recur (inc i) (+ off len)))))
 
-                       :else
-                       (into-array (flatten coord-array)))]
-       (.set (.-buffer allocated) (vec flattened) 0)
+         :else
+         (.set buf (into-array (flatten coord-array)) 0))
        allocated)))
 
 #?(:cljs

--- a/src/cljc/net/willcohen/proj/wasm.cljc
+++ b/src/cljc/net/willcohen/proj/wasm.cljc
@@ -561,7 +561,10 @@
            (let [ca-info (nth coord-arrays i)
                  original-arg (nth args (:argIdx ca-info))
                  new-data (aget returned-data i)]
-             (.set (.-buffer original-arg) (js/Float64Array.from new-data)))))
+
+             
+             
+             (.set (.-buffer original-arg) new-data))))
        (.-result result))))
 
 #?(:cljs
@@ -589,8 +592,14 @@
                     (seq coord-arrays)
                     (assoc :coordArrays
                            (mapv (fn [ca]
+                                   ;; structured clone of a view copies its
+                                   ;; whole backing buffer
                                    {:argIdx (:argIdx ca)
-                                    :data (js/Array.from (:data ca))
+                                    :data (let [^js data (:data ca)
+                                                n (:numFloats ca)]
+                                            (if (= (.-length data) n)
+                                              data
+                                              (.slice data 0 n)))
                                     :numFloats (:numFloats ca)})
                                  coord-arrays)))]
        {:args (if (seq coord-arrays)


### PR DESCRIPTION
While trying to hunt down heavy memory usage in backproj, noticed some unnecessary GC happening from arrays.